### PR TITLE
Fix Stopwatch initialization in game loop

### DIFF
--- a/Loop.cs
+++ b/Loop.cs
@@ -5,8 +5,13 @@ namespace Engine.Core;
 
 public class Loop
 {
-    private static Stopwatch _stopwatch = new();
+    private static readonly Stopwatch _stopwatch = new();
     private static long _previousFrameTicks = 0;
+
+    static Loop()
+    {
+        _stopwatch.Start();
+    }
 
     public void Update(Scene scene)
     {


### PR DESCRIPTION
## Summary
- start the `Stopwatch` when the `Loop` class is loaded

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684003d554248327ba241499d31f8952