### PR TITLE
Fix method name typo in loop

### DIFF
--- a/Loop.cs
+++ b/Loop.cs
@@ -23,7 +23,7 @@ public class Loop
         scene.Update(dt);
     }
 
-    public bool IsRunnig()
+    public bool IsRunning()
     {
         return true;
     }

--- a/Project.cs
+++ b/Project.cs
@@ -106,7 +106,7 @@ public class Project
     public void Run()
     {
         var loop = new Loop();
-        while (loop.IsRunnig())
+        while (loop.IsRunning())
         {
             loop.Update(_state.CurrentScene);
         }


### PR DESCRIPTION
## Summary
- rename `IsRunnig()` to `IsRunning()` in `Loop`
- update call site in `Project`

## Testing
- `dotnet build Engine.Core.csproj` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684004e376cc8327ad060eecf7ea8097