### PR TITLE
Fix DI container parameter error message

### DIFF
--- a/Di/DiContainer.cs
+++ b/Di/DiContainer.cs
@@ -205,8 +205,8 @@ namespace Engine.Core.Di
                 }
                 else
                 {
-                    if (!_parameters.TryGetValue(parameterInfo.Name, out var parameter)) 
-                        throw new Exception($"Can't resolve parameter {parameterInfo.Name}.There is not registered registered.");
+                    if (!_parameters.TryGetValue(parameterInfo.Name, out var parameter))
+                        throw new Exception($"Can't resolve parameter {parameterInfo.Name}. No value was registered.");
                     args[i] = parameter;
                 }
 


### PR DESCRIPTION
## Summary
- improve the error text for missing registered parameters in `DiContainer`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684004fe2d108327a4dcbf2e64072f79